### PR TITLE
Feature/質問一覧の実装

### DIFF
--- a/models/Question.ts
+++ b/models/Question.ts
@@ -1,0 +1,10 @@
+import { Timestamp } from "firebase/firestore";
+
+export interface Question {
+  id: string
+  senderUid: string
+  receiverUid: string
+  body: string
+  isReplied: boolean
+  createdAt: Timestamp
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "bootstrap": "^5.1.3",
+    "dayjs": "^1.11.0",
     "firebase": "^9.6.7",
     "next": "12.1.0",
     "react": "17.0.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,10 @@
 import { RecoilRoot } from 'recoil'
 import '../styles/globals.scss'
 import '../lib/firebase'
+import dayjs from 'dayjs'
+import 'dayjs/locale/ja'
+
+dayjs.locale('ja')
 
 function MyApp({ Component, pageProps }) {
   return (

--- a/pages/questions/received.tsx
+++ b/pages/questions/received.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import {
+  collection,
+  getDocs,
+  getFirestore,
+  query,
+  where,
+} from 'firebase/firestore'
+import { useAuthentication } from '../../hooks/authentication'
+import { Question } from '../../models/Question'
+import Layout from '../../components/Layout'
+
+export default function QuestionsReceived() {
+  const [questions, setQuestions] = useState<Question[]>([])
+  const { user } = useAuthentication()
+
+  const isServer = typeof window !== 'undefined'
+  useEffect(() => {
+    if (!isServer) {
+      return
+    }
+    if (user === null) {
+      return
+    }
+
+    async function loadQuestions() {
+      const db = getFirestore()
+      const q = query(
+        collection(db, 'questions'),
+        where('receiverUid', '==', user.uid)
+      )
+      const snapshot = await getDocs(q)
+
+      if (snapshot.empty) {
+        return
+      }
+
+      const gotQuestions = snapshot.docs.map((doc) => {
+        const question = doc.data() as Question
+        question.id = doc.id
+        return question
+      })
+      setQuestions(gotQuestions)
+    }
+
+    loadQuestions()
+  }, [isServer, user])
+
+  return (
+    <Layout>
+      <div>サンプル</div>
+    </Layout>
+  )
+}

--- a/pages/questions/received.tsx
+++ b/pages/questions/received.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs'
 import { useEffect, useState } from 'react'
 import {
   collection,
@@ -48,7 +49,21 @@ export default function QuestionsReceived() {
 
   return (
     <Layout>
-      <div>サンプル</div>
+      <h1 className="h4">受け取った質問一覧</h1>
+      <div className="row justify-content-center">
+        <div className="col-12 col-md-6">
+          {questions.map((question: Question) => (
+            <div className="card my-3" key={question.id}>
+              <div className="card-body">
+                <div className="text-truncate">{question.body}</div>
+                <div className="text-muted text-end">
+                  <small>{dayjs(question.createdAt.toDate()).format('YYYY/MM/DD HH:mm')}</small>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     </Layout>
   )
 }

--- a/pages/questions/received.tsx
+++ b/pages/questions/received.tsx
@@ -4,6 +4,7 @@ import {
   collection,
   getDocs,
   getFirestore,
+  orderBy,
   query,
   where,
 } from 'firebase/firestore'
@@ -28,7 +29,8 @@ export default function QuestionsReceived() {
       const db = getFirestore()
       const q = query(
         collection(db, 'questions'),
-        where('receiverUid', '==', user.uid)
+        where('receiverUid', '==', user.uid),
+        orderBy('createdAt', 'desc')
       )
       const snapshot = await getDocs(q)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,6 +887,11 @@ damerau-levenshtein@^1.0.7:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
+dayjs@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.0.tgz#009bf7ef2e2ea2d5db2e6583d2d39a4b5061e805"
+  integrity sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==
+
 debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
# 変更点
* 受け取った質問の一覧を表示するページの作成
* Firestoreから質問を取得する処理の実装

# 確認URL
* http://localhost:3000/questions/received
# 共有事項
* なし